### PR TITLE
Add a section to README to indicate where humans can submit event ideas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This repo is to help with knowledge sharing / transfer between all the community
 *   [ ] Catering Options
 *   [ ] Event Marketing Tips & Tricks
 
+## Suggesting Events
+
+If your meetup allows other organizers or members to suggest events, let’s hear about it!
+
+- [Node.DC](https://www.meetup.com/node-dc/) accepts talk and event suggestions at [NodeDC/talks](https://github.com/NodeDC/talks).
+
 ## Contributing
 
 For now, feel free to commit directly to the `master` branch and we'll consider a PR route if things ever get super complicated.


### PR DESCRIPTION
I think it’d be cool to collect a list of places where people can submit talks or events for Meetups, so we can direct people who are interested in speaking here. 

What do y’all think? Thanks for getting this off the ground, @bencodezen! 