### PR TITLE
Add section to README to indicate other organizer groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This repo is to help with knowledge sharing / transfer between all the community
 *   [ ] Catering Options
 *   [ ] Event Marketing Tips & Tricks
 
+## Sub-Organizing Groups
+
+If your meetup organizes itself publicly anywhere, add it to the list!
+
+- [Node.DC](https://www.meetup.com/node-dc/) does some of its organizing at [NodeDC/organizers](https://github.com/NodeDC/organizers).
+
 ## Contributing
 
 For now, feel free to commit directly to the `master` branch and we'll consider a PR route if things ever get super complicated.


### PR DESCRIPTION
I know that Node.DC sometimes organizes things at https://github.com/NodeDC/organizers, which might be helpful to link to in case someone wants to see what’s up with that group.

![bitmoji](https://render.bitstrips.com/v2/cpanel/b79fc340-29de-4217-a5d5-b263cbfa0835-0576c9e1-1d83-429c-9d9b-c131dc208eb0-v1.png?transparent=1&palette=1&width=246)